### PR TITLE
Update project for Github Action dependencies

### DIFF
--- a/github/workflows/delete-preview-when-pr-closed.yml
+++ b/github/workflows/delete-preview-when-pr-closed.yml
@@ -12,9 +12,9 @@ jobs:
   delete-deploy:
     name: Delete the deployment
     concurrency: delete-${{ github.event.pull_request.number || github.event.inputs.service_name }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set outputs
         id: vars
         run: |

--- a/github/workflows/pr-preview-workflow.yml
+++ b/github/workflows/pr-preview-workflow.yml
@@ -4,14 +4,14 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     outputs:
       sha_short: ${{ steps.vars.outputs.sha_short }}
       ref_short: ${{ steps.vars.outputs.ref_short }}
       slack-thread-ts: ${{ fromJSON(steps.send-message.outputs.slack-result).response.message.ts }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set outputs
         id: vars
         run: |
@@ -108,11 +108,11 @@ jobs:
   deploy:
     name: Deploy PR Preview to ECS
     concurrency: cd-${{ github.ref }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     needs:
       - build
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:


### PR DESCRIPTION
## Description

Support for Ubuntu 18 in Github Actions is deprecated and will be removed altogether in April 2023 - so this PR updates the relevant workflows to use Ubuntu 22 - an LTS release with several more years of support at minimum.

This change also updates the use of `actions/checkout` to `@v3` - which addresses a deprecation warning around an outdated Node version usage under-the-hood.

## Related links

- https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/
- https://github.com/actions/checkout/issues/959
