### PR TITLE
[COREINF-5948] fix: update set-output commands to use github environment files

### DIFF
--- a/github/workflows/delete-preview-when-pr-closed.yml
+++ b/github/workflows/delete-preview-when-pr-closed.yml
@@ -18,9 +18,9 @@ jobs:
       - name: Set outputs
         id: vars
         run: |
-          echo "::set-output name=sha_short::$(git rev-parse --short=8 HEAD)"
-          echo "::set-output name=ref_short::$(echo ${{ github.ref }} | cut -d / -f 3- | sed -e 's/[^a-zA-Z0-9_]/_/g')"
-          echo "::set-output name=service_name::${{ github.event.pull_request.number || github.event.inputs.service_name }}"
+          echo "sha_short=$(git rev-parse --short=8 HEAD)" >> $GITHUB_OUTPUT
+          echo "ref_short=$(echo ${{ github.ref }} | cut -d / -f 3- | sed -e 's/[^a-zA-Z0-9_]/_/g')" >> $GITHUB_OUTPUT
+          echo "service_name=${{ github.event.pull_request.number || github.event.inputs.service_name }}" >> $GITHUB_OUTPUT
 
       - name: Slack - Deployment Beginning
         uses: archive/github-actions-slack@v2.2.1

--- a/github/workflows/pr-preview-workflow.yml
+++ b/github/workflows/pr-preview-workflow.yml
@@ -15,8 +15,8 @@ jobs:
       - name: Set outputs
         id: vars
         run: |
-          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-          echo "::set-output name=ref_short::$(echo ${{ github.ref }} | cut -d / -f 3- | sed -e 's/[^a-zA-Z0-9_]/_/g')"
+          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "ref_short=$(echo ${{ github.ref }} | cut -d / -f 3- | sed -e 's/[^a-zA-Z0-9_]/_/g')" >> $GITHUB_OUTPUT
 
       - name: Slack - Deployment Beginning
         uses: archive/github-actions-slack@v2.2.1


### PR DESCRIPTION
# Description: 
This PR resolves the set-output deprecation identified by this [blog post](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

Changes include updating the `set-output` commands in our GitHub workflows to use the new environment files `$GITHUB_OUTPUT` instead of using stdout, as recommended by the blog post. This prevents any potential issues that may arise from the deprecation and ensures our workflows will continue to function properly after May 31, 2023.

Please review the changes and let me know if any further modifications are required.

# References

[Slack Thread](https://scribd.slack.com/archives/CR8SN9A4B/p1684350669751029) - Please ask any follow up questions here.
[COREINF-5948](https://scribdjira.atlassian.net/browse/COREINF-5948)


[COREINF-5948]: https://scribdjira.atlassian.net/browse/COREINF-5948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ